### PR TITLE
Fix errors on Debian GNU/Linux

### DIFF
--- a/ucpp/ucpp-init
+++ b/ucpp/ucpp-init
@@ -12,15 +12,36 @@ Options:
 EOF
 }
 
-if [ "x$1" = "x-h" ]
-then
-	usage
-fi
+source ucpp_settings
 
-if [ "x$1" = "x--help" ]
-then
-	usage
-fi
+while getopts "ht:" opt; do
+	case $opt in
+		h)
+			usage
+			exit
+			;;
+		t)
+			HUNDREDS=`expr $OPTARG / 100`
+			UNDER_HUNDREDS=`expr $OPTARG % 100`
+			DEPLOY_IP="10.${HUNDREDS}.${UNDER_HUNDREDS}.2"
+			if [ "x$DEPLOY_IP" = "x10...2" ]
+			then
+				echo "Invalid team number"
+				exit 1
+			fi
+			;;
+		\?)
+			echo "Invalid option: -$OPTARG" >&2
+			usage >&2
+			exit 1
+			;;
+		:)
+			echo "Option -$OPTARG requires an argument." >&2
+			usage >&2
+			exit 1
+			;;
+	esac
+done
 
 if [ -f .ucpp ]
 then
@@ -42,15 +63,6 @@ then
 		fi
 	fi
 fi
-
-source ucpp_settings
-
-DEPLOY_IP=$( ${UCPP_PYTHON_BIN} <<EOF 2>&1 | grep "10."
-s="$@"
-n=int(s.split("-t")[1])
-print "10.%i.%i.2\n" % (n//100, n%100)
-EOF
-)
 
 export CPP_PROJECT_WS_ROOT_DIR=$(dirname "`pwd`"| sed "s|$C_DRIVE|C:/|g")
 export CPP_PROJECT_ROOT_DIR=$(pwd | sed "s|$C_DRIVE|C:/|g")

--- a/ucpp/ucpp-setup
+++ b/ucpp/ucpp-setup
@@ -245,33 +245,34 @@ install_gccdist()
 linux_find_python2_settings()
 {
 #find python major version 2
-    if which python
+    echo "-----> Detecting python ..."
+    if [ "x`which python`" != "x" ]
     then
 	UCPP_PYTHON_MAJOR_VERSION=$( python --version 2>&1 | \
 	    sed "s/Python \([0-9]\+\).*/\1/" )
 	if [ "$UCPP_PYTHON_MAJOR_VERSION" = "2" ]
 	then
 	    UCPP_PYTHON_BIN=`which python`
-	elif which python2
+	elif [ "x`which python2`" != "x" ]
 	then
 	    UCPP_PYTHON_BIN=`which python2`
-	elif which python2.7
+	elif [ "x`which python2.7`" != "x" ]
 	then
 	    UCPP_PYTHON_BIN=`which python2.7`
-	elif which python2.6
+	elif [ "x`which python2.6`" != "x" ]
 	then
 	    UCPP_PYTHON_BIN=`which python2.6`
 	fi
     fi
     if [ "x$UCPP_PYTHON_BIN" = "x" ]
     then
-        echo "Python not found"
-	echo "Install python or add it to system PATH"
-	echo "ucpp-setup FAILED"
-	exit 1
+        echo "Python 2.x not found"
+	    echo "Install python 2 or add it to system PATH"
+	    echo "ucpp-setup FAILED"
+	    exit 1
     fi
 
-    echo "${UCPP_PYTHON_BIN}"
+    echo "-----> Python 2 found at: ${UCPP_PYTHON_BIN} [DONE]"
 }
 
 ms_windows_find_python2_dir()
@@ -303,10 +304,10 @@ then
 		exit 1
 	else
 		gen_settings
-		UCPP_PYTHON_BIN=$( linux_find_python2_settings )
+		linux_find_python2_settings
 		cat >>"$HOME/.ucpp/settings" <<EOF
 DEFAULT_CONFIGURE_COMMAND=py
-UCPP_PYTHON_BIN=\"${UCPP_PYTHON_BIN}\"
+UCPP_PYTHON_BIN="${UCPP_PYTHON_BIN}"
 EOF
 
 
@@ -316,10 +317,11 @@ fi
 if [ "$platform" = "linux-gccdist" ]
 then
 	gen_settings
+	linux_find_python2_settings
 	cat >>"$HOME/.ucpp/settings" <<EOF
 DEFAULT_CONFIGURE_COMMAND=py
+UCPP_PYTHON_BIN="${UCPP_PYTHON_BIN}"
 EOF
-	linux_find_python2_settings
 	install_gccdist
 fi
 


### PR DESCRIPTION
Note: Debian users must have ozzloy's patches, as python2 does not
exist (it's just plain python in most setups)

Fixed ucpp-setup to include UCPP_PYTHON_BIN in ~/.ucpp/settings.

Fixed ucpp-init to handle -t arguments correctly copying over code
from ucpp-setup.  Should probably add a message to ucpp-init to
warn the user that there is no deploy target set if it is not
in the global settings file and isn't specified on the command
line, but I'll leave that to the main devs cause I don't know
what they want.
